### PR TITLE
Added live Covid info Feature

### DIFF
--- a/travvy/src/components/AttractionsList.vue
+++ b/travvy/src/components/AttractionsList.vue
@@ -43,13 +43,11 @@
       <br>
       <h3>Description</h3>
       <p>{{$store.state.city}} is the largest city in {{$store.state.recommendedAttractions[0].country}}, and is home to attractions such as the {{$store.state.recommendedAttractions[0].attraction_name}}, {{$store.state.recommendedAttractions[1].attraction_name}}, and {{$store.state.recommendedAttractions[2].attraction_name}}.</p>
-      <h3>COVID-19</h3>
-      <p>Active cases: 2684</p>
-      <p>Trend: Numbers increasing</p>
-      <h3>Safety Guidelines</h3>
-      <p>{{$store.state.city}} is in phase 2</p>
-      <p>Max gathering of people indoors: 10</p>
-      <p>Masks: required</p>
+      <h3>Live COVID-19 Information</h3>
+      <p>Active Cases: {{$store.state.covidInfo.active}}</p>
+      <p>Today's Cases: {{$store.state.covidInfo.todayCases}}</p>
+      <p>Total Cases: {{$store.state.covidInfo.cases}}</p>
+      <p>Total Deaths: {{$store.state.covidInfo.deaths}}</p>
       <br>
       </div>
       <div v-else>

--- a/travvy/src/components/Home.vue
+++ b/travvy/src/components/Home.vue
@@ -84,6 +84,7 @@
  <script>
  import SelectFile from './SelectFile.vue'
  import AttractionsService from '../services/AttractionsService.js'
+ import CovidService from '../services/CovidService.js'
  import LocationsService from '../services/LocationsService.js'
  export default {
    name: 'Home',
@@ -127,6 +128,15 @@
         const response = await AttractionsService.recommend({"city": this.city, "groupSize": this.groupSize, "startDate": this.startDate, "endDate": this.endDate})
         // Saves response from recommend to the global variable in the store
         this.$store.dispatch('setRecommendedAttractions', response.data)
+        //call covid19 API based on country 
+        if(this.$store.state.recommendedAttractions.length > 0){
+          const covidInfo = await CovidService.getCovidInfo({"country":this.$store.state.recommendedAttractions[0].country})
+          console.log(covidInfo)
+          this.$store.dispatch('setCovidInfo', covidInfo.data)  
+        }
+        
+        //save the covid info in store 
+
         this.$router.push(route)
       } catch (error) {
          console.log(error)

--- a/travvy/src/services/CovidService.js
+++ b/travvy/src/services/CovidService.js
@@ -1,0 +1,30 @@
+import axios from 'axios'
+
+export default {
+  // It makes get request to recommend attractions based on city
+    getCovidInfo(country) {
+        if(country.country == 'England'){
+            const formated_country= 'UK'
+            const urlString = 'https://corona.lmao.ninja/v2/countries/'+ formated_country + '?yesterday&strict&query='
+            return axios.get(urlString)  
+            .catch(function (error) {
+              console.log(error);
+            });
+        } else if (country.country == 'United States'){
+            const formated_country = 'USA'
+            const urlString = 'https://corona.lmao.ninja/v2/countries/'+ formated_country + '?yesterday&strict&query='
+            return axios.get(urlString)  
+            .catch(function (error) {
+              console.log(error);
+            });
+        } else{
+            const formated_country = country.country
+            const urlString = 'https://corona.lmao.ninja/v2/countries/'+ formated_country + '?yesterday&strict&query='
+            return axios.get(urlString)  
+            .catch(function (error) {
+              console.log(error);
+            });
+        }
+
+}
+}

--- a/travvy/src/store/store.js
+++ b/travvy/src/store/store.js
@@ -16,7 +16,8 @@ export default new Vuex.Store({
         gender: null,
         instagram: null,
         name: null,
-        activity: null
+        activity: null,
+        covidInfo: null, 
     },
     mutations: {
         // If user selects new locations, recommended attractions change
@@ -47,6 +48,9 @@ export default new Vuex.Store({
         },
         setActivity(state,activity){
             state.activity = activity
+        }, 
+        setCovidInfo(state,covidInfo){
+            state.covidInfo = covidInfo
         }
     }, 
     actions: {
@@ -78,6 +82,9 @@ export default new Vuex.Store({
         },
         setActivity({commit},activity){
             commit('setActivity', activity)
+        }, 
+        setCovidInfo({commit},covidInfo){
+            commit('setCovidInfo', covidInfo)
         }
     },
   


### PR DESCRIPTION
- Now on the Attractions Details page live covid info information will be displayed based on public api 
https://postman-toolboxes.github.io/covid-19/#featured-collections
- Looking for feedback on which information to include out of these available options 
![image](https://user-images.githubusercontent.com/29102596/99893235-8924ed00-2c4b-11eb-9ffc-4927fcd8e918.png)
- Note: recovered data set does not seem to be reliable as it is zero for the UK
