### PR TITLE
Fixed Back button to navigate back to attractions list

### DIFF
--- a/travvy/src/components/AttractionDetails.vue
+++ b/travvy/src/components/AttractionDetails.vue
@@ -1,7 +1,9 @@
 <template>
   <div>
     <!-- Button to go to go back to the AttractionsList page -->
-    <router-link to="/AttractionList" tag="button" class="back"><span>Back</span></router-link>
+    
+    <button class="back" @click="$router.go(-1)">Back</button>
+  
     
     <h1>{{$store.state.recommendedAttractions[id].attraction_name}} </h1>
     <img src="../images/toronto.jpg" alt="Picture of Toronto"/>


### PR DESCRIPTION
- Added the functionality on the back button to allow users to go back to the attractions list from an attractions details page
- Previously users were taken to a blank screen
- Changed the button from a router link with the tag button to be a button with a class that allows you to navigate to the previous page