### PR TITLE
Added preference consent button

### DIFF
--- a/test/unitTests.js
+++ b/test/unitTests.js
@@ -112,7 +112,7 @@ describe('Recommend Attractions User without Preferences Test', function() {
               assert.equal(response.length,6);
         })
     });
-describe('Recommend Attractions User without Preferences Test', function() {
+describe('Recommend Attractions User without Preferences no Recomendations Test', function() {
     it('Recommend Attractions User without Preferences should return 6', async function() {
             const response = await RecommendController.recommend(city2,groupSize,startDate,endDate,userEmailWithoutPreferences,preferenceConsentYes)
             assert.equal(response.length,6);

--- a/test/unitTests.js
+++ b/test/unitTests.js
@@ -84,6 +84,7 @@ const startDate = new Date("2020-11-05")
 const endDate = new Date("2021-01-05")
 const userEmailWithPreferences = 'dyampolsky@uwaterloo.ca'
 const userEmailWithoutPreferences = 'lucytest@test.ca'
+const preferenceConsentYes = 'Yes'
 
 describe('Recommend Attractions No User Info Test', function() {
  it('Recommend Attractions No User Info Test should return 4', async function() {
@@ -98,6 +99,12 @@ describe('Recommend Attractions User with Preferences Test', function() {
               assert.equal(response.length,1);
         })
     });
+describe('Recommend Attractions User with Preferences no Recomendations Test', function() {
+    it('Recommend Attractions User with Preferences should return 1', async function() {
+            const response = await RecommendController.recommend(city2,groupSize,startDate,endDate,userEmailWithPreferences,preferenceConsentYes)
+            assert.equal(response.length,6);
+    })
+});
 
 describe('Recommend Attractions User without Preferences Test', function() {
         it('Recommend Attractions User without Preferences should return 6', async function() {
@@ -105,6 +112,12 @@ describe('Recommend Attractions User without Preferences Test', function() {
               assert.equal(response.length,6);
         })
     });
+describe('Recommend Attractions User without Preferences Test', function() {
+    it('Recommend Attractions User without Preferences should return 6', async function() {
+            const response = await RecommendController.recommend(city2,groupSize,startDate,endDate,userEmailWithoutPreferences,preferenceConsentYes)
+            assert.equal(response.length,6);
+    })
+});
 //test the getUser function
 describe('Correct email get user test', function() {
  it('Get user should not return null with the a correct email', async function() {

--- a/travvy-server/routes/routes.js
+++ b/travvy-server/routes/routes.js
@@ -12,7 +12,7 @@ module.exports = (app) => {
     endDate = new Date(req.query.endDate)
     //endDate = endDate.setFullYear(endDate.getFullYear()-nonfilteredStartDate.getFullYear() > 0 ? 0 : 1)
 
-    RecommendController.recommend(req.query.city,groupSize,startDate,endDate,req.query.user)
+    RecommendController.recommend(req.query.city,groupSize,startDate,endDate,req.query.user,req.query.preference)
       .then(attraction => res.status(200).send(attraction))
       .catch(error => res.status(500).send(error))
   }),

--- a/travvy-server/src/controllers/RecommendController.js
+++ b/travvy-server/src/controllers/RecommendController.js
@@ -7,8 +7,8 @@ const Activity =  require('../models').Activity
 
 // This is the logic for queriying database for attraction information for the desired city
 module.exports = {
-  async recommend (city, groupSize, startDate, endDate,user) {   
-    if(user == null){
+  async recommend (city, groupSize, startDate, endDate,user,preferences) {   
+    if(user == null || preferences == 'Yes'){
       activity_ids = await Activity.findAll({
         attributes: ['activity_id'],
         model: Activity,

--- a/travvy/src/components/Home.vue
+++ b/travvy/src/components/Home.vue
@@ -147,7 +147,6 @@
       try {
         //saves users city in the store
         this.$store.dispatch('setCity', this.city)
-        console.log(this.preference_consent[0])
         const response = await AttractionsService.recommend({"city": this.city, "groupSize": this.groupSize, "startDate": this.startDate, "endDate": this.endDate, "user":this.$store.state.userEmail, "preference":this.preference_consent[0]})
         // Saves response from recommend to the global variable in the store
         this.$store.dispatch('setRecommendedAttractions', response.data)

--- a/travvy/src/components/Home.vue
+++ b/travvy/src/components/Home.vue
@@ -55,6 +55,14 @@
     <input type="text" id="groupSize" class="travellers input" v-model="groupSize">
     <br>
     <br>
+     <!-- if a user is signed in give them the option of not using their preferences -->
+    <div v-if="$store.state.userEmail != null">
+    <label for="checkbox">     Would you like your preferences ignored?:</label>
+    <input type="checkbox" id="checkbox" value="Yes" v-model="preference_consent">
+    <span> {{ preference_consent[0] }}</span>
+    </div>
+    <br>
+    <br>
 
     <center><button v-on:click="navigateTo({name:'AttractionsList'})" class="search"><span>Search </span></button></center>
   
@@ -126,7 +134,8 @@
        startDate: '',
        endDate: '',
        error:null,
-       file: null
+       file: null,
+       preference_consent:[]
 
      }
    },
@@ -138,7 +147,8 @@
       try {
         //saves users city in the store
         this.$store.dispatch('setCity', this.city)
-        const response = await AttractionsService.recommend({"city": this.city, "groupSize": this.groupSize, "startDate": this.startDate, "endDate": this.endDate, "user":this.$store.state.userEmail})
+        console.log(this.preference_consent[0])
+        const response = await AttractionsService.recommend({"city": this.city, "groupSize": this.groupSize, "startDate": this.startDate, "endDate": this.endDate, "user":this.$store.state.userEmail, "preference":this.preference_consent[0]})
         // Saves response from recommend to the global variable in the store
         this.$store.dispatch('setRecommendedAttractions', response.data)
         //call covid19 API based on country 

--- a/travvy/src/services/AttractionsService.js
+++ b/travvy/src/services/AttractionsService.js
@@ -3,8 +3,8 @@ import axios from 'axios'
 
 export default {
   // It makes get request to recommend attractions based on city
-    recommend(city,groupSize,startDate,endDate,user) {
-        return axios.get('/recommend', {params:city,groupSize,startDate,endDate,user})  
+    recommend(city,groupSize,startDate,endDate,user,preference) {
+        return axios.get('/recommend', {params:city,groupSize,startDate,endDate,user,preference})  
           .catch(function (error) {
             console.log(error);
           });


### PR DESCRIPTION
- Now if user is signed in they will be given the option to opt out of their preference information being taken into account to recommend attractions 
- Note: The checkbox will only appear if the user is signed in, if a user is not signed in the recommend endpoint automatically recommends without taking into account preferences 
- Made changes to old unit tests + unit tested changes